### PR TITLE
Upgrade to Laravel 5.7

### DIFF
--- a/template/composer.json.stub
+++ b/template/composer.json.stub
@@ -7,11 +7,11 @@
   "minimum-stability": "stable",
   "require": {
     "php" : "^7.1",
-    "illuminate/support": "~5.5.0|~5.6.0"
+    "illuminate/support": "~5.6.0|~5.7.0"
   },
   "require-dev": {
     "phpunit/phpunit": "^6.3|^7.0",
-    "orchestra/testbench": "~3.5.0|~3.6.0"
+    "orchestra/testbench": "~3.6.0|~3.7.0"
   },
   "autoload": {
     "psr-4": {


### PR DESCRIPTION
This PR updates the stub composer.json to create packages for Laravel 5.7 instead of Laravel 5.5. Support for Laravel 5.6 still stays.

---

closes #15 